### PR TITLE
Middleware improvements

### DIFF
--- a/example-app/src/app.ts
+++ b/example-app/src/app.ts
@@ -32,7 +32,9 @@ export type MyRelayerContext = LoggingContext &
 
 // You need to read in your keys
 const privateKeys = {
-  [CHAIN_ID_SOLANA]: [process.env.SOLANA_KEY],
+  [CHAIN_ID_SOLANA]: [
+    "3gE6stQnNinp8R2RYkX3mpw5rBkZqgGNyd8A1PCs6z6ra9XaLmRaNXCxBNkUfVMYi4TobuMbt4vuQmk9VQVGoofw",
+  ], // you could do process.env.SOLANA_KEY
 };
 
 async function main() {
@@ -50,7 +52,7 @@ async function main() {
   app.use(missedVaas(app, { namespace: "simple", logger: rootLogger }));
   app.use(providers());
   app.use(
-    wallets({
+    wallets(env, {
       logger: rootLogger,
       namespace: "simple",
       privateKeys,

--- a/example-app/src/log.ts
+++ b/example-app/src/log.ts
@@ -3,7 +3,7 @@ import * as winston from "winston";
 export const rootLogger = winston.createLogger({
   transports: [
     new winston.transports.Console({
-      level: "info",
+      level: "debug",
     }),
   ],
   format: winston.format.combine(

--- a/example-app/src/log.ts
+++ b/example-app/src/log.ts
@@ -3,7 +3,7 @@ import * as winston from "winston";
 export const rootLogger = winston.createLogger({
   transports: [
     new winston.transports.Console({
-      level: "debug",
+      level: process.env.LOG_LEVEL || "debug",
     }),
   ],
   format: winston.format.combine(

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@certusone/wormhole-sdk": "^0.9.11",
         "@certusone/wormhole-spydk": "^0.0.1",
         "@datastructures-js/queue": "^4.2.3",
-        "@xlabs-xyz/wallet-monitor": "^0.0.5",
+        "@xlabs-xyz/wallet-monitor": "^0.0.11",
         "bech32": "^2.0.0",
         "bs58": "^5.0.0",
         "bullmq": "^3.10.1",
@@ -2192,9 +2192,9 @@
       }
     },
     "node_modules/@xlabs-xyz/wallet-monitor": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@xlabs-xyz/wallet-monitor/-/wallet-monitor-0.0.5.tgz",
-      "integrity": "sha512-DboDxIwczZ9b3XbObZwTOhBO3vcvpVsVSx57sh6KMSJhfSmmphIdBqDdpTrgLtn/YfQAqfHBEWClN6OYwBHRAw==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@xlabs-xyz/wallet-monitor/-/wallet-monitor-0.0.11.tgz",
+      "integrity": "sha512-crLNnVT2Uh0EtMLZf55IcFeneuAEqdZjJjZhequheVclPUsKmNnbemOuK0FD43xhVlCMgF9fw5dVm+JzKMEopQ==",
       "dependencies": {
         "@solana/spl-token": "^0.3.7",
         "@solana/web3.js": "^1.74.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,9 @@
         "@certusone/wormhole-sdk": "^0.9.11",
         "@certusone/wormhole-spydk": "^0.0.1",
         "@datastructures-js/queue": "^4.2.3",
+        "@xlabs-xyz/wallet-monitor": "^0.0.5",
         "bech32": "^2.0.0",
+        "bs58": "^5.0.0",
         "bullmq": "^3.10.1",
         "ethers": "^5.7.2",
         "generic-pool": "^3.9.0",
@@ -25,6 +27,7 @@
         "winston": "^3.8.2"
       },
       "devDependencies": {
+        "@types/bs58": "^4.0.1",
         "@types/koa": "^2.13.5",
         "@types/winston": "^2.4.4",
         "prettier": "^2.8.4"
@@ -157,6 +160,14 @@
       "dependencies": {
         "@types/long": "^4.0.2",
         "@types/node": "^18.0.3"
+      }
+    },
+    "node_modules/@certusone/wormhole-sdk/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dependencies": {
+        "base-x": "^3.0.2"
       }
     },
     "node_modules/@certusone/wormhole-spydk": {
@@ -1594,6 +1605,14 @@
         "node": ">=11"
       }
     },
+    "node_modules/@project-serum/anchor/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
     "node_modules/@project-serum/borsh": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@project-serum/borsh/-/borsh-0.2.5.tgz",
@@ -1742,9 +1761,9 @@
       }
     },
     "node_modules/@solana/web3.js": {
-      "version": "1.73.2",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.73.2.tgz",
-      "integrity": "sha512-9WACF8W4Nstj7xiDw3Oom22QmrhBh0VyZyZ7JvvG3gOxLWLlX3hvm5nPVJOGcCE/9fFavBbCUb5A6CIuvMGdoA==",
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.74.0.tgz",
+      "integrity": "sha512-RKZyPqizPCxmpMGfpu4fuplNZEWCrhRBjjVstv5QnAJvgln1jgOfgui+rjl1ExnqDnWKg9uaZ5jtGROH/cwabg==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@noble/ed25519": "^1.7.0",
@@ -1759,12 +1778,17 @@
         "buffer": "6.0.1",
         "fast-stable-stringify": "^1.0.0",
         "jayson": "^3.4.4",
-        "node-fetch": "2",
-        "rpc-websockets": "^7.5.0",
+        "node-fetch": "^2.6.7",
+        "rpc-websockets": "^7.5.1",
         "superstruct": "^0.14.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dependencies": {
+        "base-x": "^3.0.2"
       }
     },
     "node_modules/@solana/web3.js/node_modules/buffer": {
@@ -1936,6 +1960,15 @@
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-yfAgiWgVLjFCmRv8zAcOIHywYATEwiTVccTLnRp6UxTNavT55M9d/uhK3T03St/+8/z/wW+CRjGKUNmEqoHHCA==",
+      "dev": true,
+      "dependencies": {
+        "base-x": "^3.0.6"
       }
     },
     "node_modules/@types/connect": {
@@ -2156,6 +2189,65 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@xlabs-xyz/wallet-monitor": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@xlabs-xyz/wallet-monitor/-/wallet-monitor-0.0.5.tgz",
+      "integrity": "sha512-DboDxIwczZ9b3XbObZwTOhBO3vcvpVsVSx57sh6KMSJhfSmmphIdBqDdpTrgLtn/YfQAqfHBEWClN6OYwBHRAw==",
+      "dependencies": {
+        "@solana/spl-token": "^0.3.7",
+        "@solana/web3.js": "^1.74.0",
+        "bluebird": "^3.7.2",
+        "ethers": "^5.7.0",
+        "koa": "^2.14.1",
+        "koa-router": "^12.0.0",
+        "prom-client": "^14.2.0"
+      }
+    },
+    "node_modules/@xlabs-xyz/wallet-monitor/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@xlabs-xyz/wallet-monitor/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@xlabs-xyz/wallet-monitor/node_modules/koa-router": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-12.0.0.tgz",
+      "integrity": "sha512-zGrdiXygGYW8WvrzeGsHZvKnHs4DzyGoqJ9a8iHlRkiwuEAOAPyI27//OlhoWdgFAEIM3qbUgr0KCuRaP/TCag==",
+      "dependencies": {
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "methods": "^1.1.2",
+        "path-to-regexp": "^6.2.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@xlabs-xyz/wallet-monitor/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/@xpla/xpla.js": {
@@ -2500,6 +2592,14 @@
         "text-encoding-utf-8": "^1.0.2"
       }
     },
+    "node_modules/borsh/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2533,12 +2633,17 @@
       }
     },
     "node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
-        "base-x": "^3.0.2"
+        "base-x": "^4.0.0"
       }
+    },
+    "node_modules/bs58/node_modules/base-x": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/bs58check": {
       "version": "2.1.2",
@@ -2548,6 +2653,14 @@
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/bs58check/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dependencies": {
+        "base-x": "^3.0.2"
       }
     },
     "node_modules/buffer": {
@@ -3008,6 +3121,14 @@
         "ripemd160-min": "0.0.6",
         "safe-buffer": "^5.2.0",
         "sha3": "^2.1.1"
+      }
+    },
+    "node_modules/crypto-addr-codec/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dependencies": {
+        "base-x": "^3.0.2"
       }
     },
     "node_modules/crypto-hash": {
@@ -4710,6 +4831,14 @@
         "tweetnacl": "^1.0.1"
       }
     },
+    "node_modules/near-api-js/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
     "node_modules/near-api-js/node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5215,9 +5344,9 @@
       }
     },
     "node_modules/rpc-websockets": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.5.0.tgz",
-      "integrity": "sha512-9tIRi1uZGy7YmDjErf1Ax3wtqdSSLIlnmL5OtOzgd5eqPKbsPpwDP5whUDO2LQay3Xp0CcHlcNSGzacNRluBaQ==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.5.1.tgz",
+      "integrity": "sha512-kGFkeTsmd37pHPMaHIgN1LVKXMi0JD782v4Ds9ZKtLlwdTKjn+CxM9A9/gLT2LaOuEcEFGL98h1QWQtlOIdW0w==",
       "dependencies": {
         "@babel/runtime": "^7.17.2",
         "eventemitter3": "^4.0.7",
@@ -5234,9 +5363,9 @@
       }
     },
     "node_modules/rpc-websockets/node_modules/ws": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
-      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "@certusone/wormhole-sdk": "^0.9.11",
     "@certusone/wormhole-spydk": "^0.0.1",
     "@datastructures-js/queue": "^4.2.3",
+    "@xlabs-xyz/wallet-monitor": "^0.0.5",
     "bech32": "^2.0.0",
+    "bs58": "^5.0.0",
     "bullmq": "^3.10.1",
     "ethers": "^5.7.2",
     "generic-pool": "^3.9.0",
@@ -30,6 +32,7 @@
     "winston": "^3.8.2"
   },
   "devDependencies": {
+    "@types/bs58": "^4.0.1",
     "@types/koa": "^2.13.5",
     "@types/winston": "^2.4.4",
     "prettier": "^2.8.4"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@certusone/wormhole-sdk": "^0.9.11",
     "@certusone/wormhole-spydk": "^0.0.1",
     "@datastructures-js/queue": "^4.2.3",
-    "@xlabs-xyz/wallet-monitor": "^0.0.5",
+    "@xlabs-xyz/wallet-monitor": "^0.0.11",
     "bech32": "^2.0.0",
     "bs58": "^5.0.0",
     "bullmq": "^3.10.1",

--- a/relayer/application-standard.ts
+++ b/relayer/application-standard.ts
@@ -40,6 +40,7 @@ const defaultOpts: Partial<StandardRelayerAppOpts> = {
   workflows: {
     retries: 3,
   },
+  redis: {},
   fetchSourceTxhash: true,
 };
 

--- a/relayer/application-standard.ts
+++ b/relayer/application-standard.ts
@@ -40,7 +40,7 @@ const defaultOpts: Partial<StandardRelayerAppOpts> = {
   workflows: {
     retries: 3,
   },
-  fetchSourceTxhash: true
+  fetchSourceTxhash: true,
 };
 
 export type StandardRelayerContext = LoggingContext &
@@ -58,10 +58,16 @@ export class StandardRelayerApp<
     const logger = opts.logger;
     delete opts.logger;
     // now we can merge
-    opts = mergeDeep({},defaultOpts, opts);
+    opts = mergeDeep({}, defaultOpts, opts);
 
-    const { privateKeys, name, spyEndpoint, redis, redisCluster, redisClusterEndpoints } =
-      opts;
+    const {
+      privateKeys,
+      name,
+      spyEndpoint,
+      redis,
+      redisCluster,
+      redisClusterEndpoints,
+    } = opts;
     super(env, opts);
     this.spy(spyEndpoint);
     this.useStorage({
@@ -75,14 +81,34 @@ export class StandardRelayerApp<
     this.logger(logger);
     this.use(logging(logger)); // <-- logging middleware
     this.use(
-      missedVaas(this, { namespace: name, logger, redis, redisCluster, redisClusterEndpoints })
+      missedVaas(this, {
+        namespace: name,
+        logger,
+        redis,
+        redisCluster,
+        redisClusterEndpoints,
+      })
     );
     this.use(providers());
     if (opts.privateKeys && Object.keys(opts.privateKeys).length) {
-      this.use(wallets({ logger, namespace: name, privateKeys })); // <-- you need valid private keys to turn on this middleware
+      this.use(
+        wallets(env, {
+          logger,
+          namespace: name,
+          privateKeys,
+          metrics: { registry: this.metricsRegistry },
+        })
+      ); // <-- you need valid private keys to turn on this middleware
     }
     this.use(tokenBridgeContracts());
-    this.use(stagingArea({ namespace: name, redisCluster, redis, redisClusterEndpoints }));
+    this.use(
+      stagingArea({
+        namespace: name,
+        redisCluster,
+        redis,
+        redisClusterEndpoints,
+      })
+    );
     if (opts.fetchSourceTxhash) {
       this.use(sourceTx());
     }

--- a/relayer/application.ts
+++ b/relayer/application.ts
@@ -225,6 +225,7 @@ export class RelayerApp<ContextT extends Context> {
       config: {
         spyFilters: await this.spyFilters(),
       },
+      locals: {},
     };
     Object.assign(ctx, opts);
     try {
@@ -427,7 +428,7 @@ export class RelayerApp<ContextT extends Context> {
    * - worklow_processing_duration: Processing time for completed jobs (processing until completed)
    * - workflow_total_duration: Processing time for completed jobs (processing until completed)
    */
-  metricsRegistry() {
+  get metricsRegistry() {
     return this.storage?.registry;
   }
 

--- a/relayer/context.ts
+++ b/relayer/context.ts
@@ -16,7 +16,7 @@ export type FetchVaasFn = (
 export interface Context {
   vaa?: ParsedVaa;
   vaaBytes?: Buffer;
-
+  locals: Record<any, any>;
   fetchVaa: FetchVaaFn;
   fetchVaas: FetchVaasFn;
   processVaa: (vaa: Buffer) => Promise<void>;

--- a/relayer/middleware/missedVaas.middleware.ts
+++ b/relayer/middleware/missedVaas.middleware.ts
@@ -104,24 +104,19 @@ export function missedVaas(
         "No missed VAAs detected between this VAA and the last VAA we processed."
       );
     }
-    await redisPool.release(redis);
     try {
-      await next(); // <-- process the current vaa
+      await setLastSequenceForContract(
+        redis,
+        vaa.emitterChain,
+        vaa.emitterAddress,
+        vaa.sequence,
+        ctx.logger
+      );
     } finally {
-      let redis;
-      try {
-        redis = await redisPool.acquire();
-        await setLastSequenceForContract(
-          redis,
-          vaa.emitterChain,
-          vaa.emitterAddress,
-          vaa.sequence,
-          ctx.logger
-        );
-      } finally {
-        await redisPool.release(redis);
-      }
+      await redisPool.release(redis);
     }
+
+    await next(); // <-- process the current vaa
   };
 }
 

--- a/relayer/middleware/providers.middleware.ts
+++ b/relayer/middleware/providers.middleware.ts
@@ -1,6 +1,9 @@
 import { Middleware } from "../compose.middleware";
 import { Context } from "../context";
 import {
+  CHAIN_ID_ACALA,
+  CHAIN_ID_ALGORAND,
+  CHAIN_ID_APTOS,
   CHAIN_ID_BSC,
   CHAIN_ID_CELO,
   CHAIN_ID_ETH,
@@ -38,6 +41,7 @@ export interface ProvidersOpts {
 
 const defaultSupportedChains = {
   [Environment.MAINNET]: {
+    [CHAIN_ID_SOLANA]: { endpoints: ["https://api.mainnet-beta.solana.com"] },
     [CHAIN_ID_ETH]: { endpoints: ["https://rpc.ankr.com/eth"] },
     [CHAIN_ID_BSC]: { endpoints: ["https://bsc-dataseed1.binance.org/"] },
     [CHAIN_ID_POLYGON]: { endpoints: ["https://rpc.ankr.com/polygon"] },
@@ -45,8 +49,17 @@ const defaultSupportedChains = {
     [CHAIN_ID_FANTOM]: { endpoints: ["https://rpc.ftm.tools"] },
     [CHAIN_ID_CELO]: { endpoints: ["https://forno.celo.org"] },
     [CHAIN_ID_MOONBEAM]: { endpoints: ["https://rpc.api.moonbeam.network"] },
+    [CHAIN_ID_ACALA]: { endpoints: ["https://eth-rpc-acala.aca-api.network"] },
+    [CHAIN_ID_ALGORAND]: { endpoints: ["https://node.algoexplorerapi.io/"] },
+    [CHAIN_ID_APTOS]: {
+      endpoints: ["https://fullnode.mainnet.aptoslabs.com/v1"],
+    },
   },
   [Environment.TESTNET]: {
+    [CHAIN_ID_ALGORAND]: { endpoints: ["node.testnet.algoexplorerapi.io/"] },
+    [CHAIN_ID_SOLANA]: {
+      endpoints: ["https://api.devnet.solana.com"],
+    },
     [CHAIN_ID_ETH]: {
       endpoints: [
         "https://eth-goerli.g.alchemy.com/v2/mvFFcUhFfHujAOewWU8kH5D1R2bgFgLt",
@@ -67,6 +80,9 @@ const defaultSupportedChains = {
     },
     [CHAIN_ID_MOONBEAM]: {
       endpoints: ["https://rpc.testnet.moonbeam.network"],
+    },
+    [CHAIN_ID_APTOS]: {
+      endpoints: ["https://fullnode.devnet.aptoslabs.com/v1"],
     },
   },
   [Environment.DEVNET]: {},

--- a/relayer/middleware/providers.middleware.ts
+++ b/relayer/middleware/providers.middleware.ts
@@ -90,7 +90,14 @@ const defaultSupportedChains = {
       endpoints: ["https://fullnode.devnet.aptoslabs.com/v1"],
     },
   },
-  [Environment.DEVNET]: {},
+  [Environment.DEVNET]: {
+    [CHAIN_ID_ETH]: {
+      endpoints: ["http://localhost:8545/"],
+    },
+    [CHAIN_ID_BSC]: {
+      endpoints: ["http://localhost:8546/"],
+    },
+  },
 };
 
 /**

--- a/relayer/middleware/source-tx.middleware.ts
+++ b/relayer/middleware/source-tx.middleware.ts
@@ -54,9 +54,10 @@ export function sourceTx(
         );
         await sleep(attempt * 200); // linear wait
       }
-    } while (attempt < opts.retries && txHash === "");
+    } while (attempt < opts.retries && !txHash);
     if (
       isEVMChain(ctx.vaa.emitterChain as ChainId) &&
+      txHash &&
       !txHash.startsWith("0x")
     ) {
       txHash = `0x${txHash}`;
@@ -87,5 +88,5 @@ async function fetchVaaHash(
   } else if (res.status > 500) {
     throw new Error(`Got: ${res.status}`);
   }
-  return (await res.json()).data?.txHash;
+  return (await res.json()).data?.txHash || "";
 }

--- a/relayer/middleware/source-tx.middleware.ts
+++ b/relayer/middleware/source-tx.middleware.ts
@@ -3,6 +3,7 @@ import { Middleware } from "../compose.middleware";
 import { Context } from "../context";
 import { Environment } from "../application";
 import { sleep } from "../utils";
+import { ChainId, isEVMChain } from "@certusone/wormhole-sdk";
 
 export interface SourceTxOpts {
   wormscanEndpoint: string;
@@ -54,6 +55,12 @@ export function sourceTx(
         await sleep(attempt * 200); // linear wait
       }
     } while (attempt < opts.retries && txHash === "");
+    if (
+      isEVMChain(ctx.vaa.emitterChain as ChainId) &&
+      !txHash.startsWith("0x")
+    ) {
+      txHash = `0x${txHash}`;
+    }
     ctx.logger?.debug(
       txHash === ""
         ? "Could not retrive tx hash."

--- a/relayer/middleware/wallet/wallet.middleware.ts
+++ b/relayer/middleware/wallet/wallet.middleware.ts
@@ -155,8 +155,14 @@ function buildMonitoringFromPrivateKeys(
       }
     } else if (CHAIN_ID_SOLANA === chainId) {
       for (const key of keys) {
+        let secretKey;
+        try {
+          secretKey = new Uint8Array(JSON.parse(key));
+        } catch (e) {
+          secretKey = bs58.decode(key);
+        }
         addresses[
-          solana.Keypair.fromSecretKey(bs58.decode(key)).publicKey.toBase58()
+          solana.Keypair.fromSecretKey(secretKey).publicKey.toBase58()
         ] = [];
       }
     }

--- a/relayer/middleware/wallet/wallet.middleware.ts
+++ b/relayer/middleware/wallet/wallet.middleware.ts
@@ -1,18 +1,26 @@
+import * as bs58 from "bs58";
 import { ethers } from "ethers";
 import * as solana from "@solana/web3.js";
 import {
+  CHAIN_ID_ETH,
   CHAIN_ID_SOLANA,
   CHAIN_ID_TO_NAME,
   ChainId,
+  coalesceChainName,
   EVMChainId,
+  isEVMChain,
 } from "@certusone/wormhole-sdk";
 import { WalletToolBox } from "./walletToolBox";
 import { Middleware } from "../../compose.middleware";
-import { Context } from "../../context";
 import { spawnWalletWorker } from "./wallet.worker";
 import { Queue } from "@datastructures-js/queue";
 import { ProviderContext } from "../providers.middleware";
 import { Logger } from "winston";
+import { MultiWalletExporter } from "@xlabs-xyz/wallet-monitor";
+import { Registry } from "prom-client";
+import { MultiWalletWatcherConfig } from "@xlabs-xyz/wallet-monitor/lib/multi-wallet-watcher";
+import { Environment } from "../../application";
+import { CHAIN_ID_AVAX } from "@certusone/wormhole-sdk/lib/cjs/utils/consts";
 
 export type EVMWallet = ethers.Wallet;
 
@@ -96,9 +104,55 @@ export interface WalletOpts {
     [k in ChainId]: any[];
   }>;
   logger?: Logger;
+  metrics?: {
+    registry: Registry;
+  };
 }
 
-export function wallets(opts: WalletOpts): Middleware<WalletContext> {
+const networks = {
+  [Environment.MAINNET]: {
+    [CHAIN_ID_ETH]: "mainnet",
+  },
+  [Environment.TESTNET]: {
+    [CHAIN_ID_ETH]: "goerli",
+    [CHAIN_ID_SOLANA]: "devnet",
+    [CHAIN_ID_AVAX]: "testnet",
+  },
+  [Environment.DEVNET]: {},
+};
+
+function buildMonitoringFromPrivateKeys(
+  env: Environment,
+  privateKeys: Partial<{
+    [k in ChainId]: any[];
+  }>
+): MultiWalletWatcherConfig {
+  const networkByChain: any = networks[env];
+  const config: MultiWalletWatcherConfig = {};
+  for (const [chainIdStr, keys] of Object.entries(privateKeys)) {
+    const chainId = Number(chainIdStr) as ChainId;
+    const chainName = coalesceChainName(chainId);
+    let addresses: Record<string, string[]> = {};
+    if (isEVMChain(chainId)) {
+      for (const key of keys) {
+        addresses[new ethers.Wallet(key).address] = [];
+      }
+    } else if (CHAIN_ID_SOLANA === chainId) {
+      for (const key of keys) {
+        addresses[
+          solana.Keypair.fromSecretKey(bs58.decode(key)).publicKey.toBase58()
+        ] = [];
+      }
+    }
+    config[chainName] = { addresses, network: networkByChain[chainId] };
+  }
+  return config;
+}
+
+export function wallets(
+  env: Environment,
+  opts: WalletOpts
+): Middleware<WalletContext> {
   const workerInfoMap = new Map<ChainId, WorkerInfo[]>(
     Object.entries(opts.privateKeys).map(([chainIdStr, keys]) => {
       //TODO update for all ecosystems
@@ -112,6 +166,10 @@ export function wallets(opts: WalletOpts): Middleware<WalletContext> {
       return [chainId, workerInfos];
     })
   );
+  const wallets = buildMonitoringFromPrivateKeys(env, opts.privateKeys);
+
+  opts.logger?.info(JSON.stringify(wallets, null, 2));
+
   let executeFunction: ActionExecutor;
   return async (ctx: WalletContext, next) => {
     if (!executeFunction) {
@@ -130,6 +188,13 @@ export function wallets(opts: WalletOpts): Middleware<WalletContext> {
         opts.logger
       );
       ctx.logger?.debug(`Initialized wallets`);
+      if (opts.metrics) {
+        const exporter = new MultiWalletExporter(wallets, {
+          logger: opts.logger,
+          prometheus: { registry: opts.metrics.registry },
+        });
+        exporter.start();
+      }
     }
 
     ctx.logger?.debug("wallets attached to context");

--- a/relayer/middleware/wallet/wallet.middleware.ts
+++ b/relayer/middleware/wallet/wallet.middleware.ts
@@ -2,7 +2,10 @@ import * as bs58 from "bs58";
 import { ethers } from "ethers";
 import * as solana from "@solana/web3.js";
 import {
+  CHAIN_ID_BSC,
+  CHAIN_ID_CELO,
   CHAIN_ID_ETH,
+  CHAIN_ID_MOONBEAM,
   CHAIN_ID_SOLANA,
   CHAIN_ID_TO_NAME,
   ChainId,
@@ -20,7 +23,11 @@ import { MultiWalletExporter } from "@xlabs-xyz/wallet-monitor";
 import { Registry } from "prom-client";
 import { MultiWalletWatcherConfig } from "@xlabs-xyz/wallet-monitor/lib/multi-wallet-watcher";
 import { Environment } from "../../application";
-import { CHAIN_ID_AVAX } from "@certusone/wormhole-sdk/lib/cjs/utils/consts";
+import {
+  CHAIN_ID_AVAX,
+  CHAIN_ID_FANTOM,
+  CHAIN_ID_POLYGON,
+} from "@certusone/wormhole-sdk/lib/cjs/utils/consts";
 
 export type EVMWallet = ethers.Wallet;
 
@@ -117,6 +124,11 @@ const networks = {
     [CHAIN_ID_ETH]: "goerli",
     [CHAIN_ID_SOLANA]: "devnet",
     [CHAIN_ID_AVAX]: "testnet",
+    [CHAIN_ID_CELO]: "alfajores",
+    [CHAIN_ID_BSC]: "testnet",
+    [CHAIN_ID_POLYGON]: "mumbai",
+    [CHAIN_ID_FANTOM]: "testnet",
+    [CHAIN_ID_MOONBEAM]: "moonbase-alpha",
   },
   [Environment.DEVNET]: {},
 };

--- a/relayer/middleware/wallet/wallet.worker.ts
+++ b/relayer/middleware/wallet/wallet.worker.ts
@@ -5,8 +5,8 @@ import { createWalletToolbox } from "./walletToolBox";
 import { ActionWithCont, WorkerInfo } from "./wallet.middleware";
 import { sleep } from "../../utils";
 
-const DEFAULT_WORKER_RESTART_MS = 10 * 1000;
-const DEFAULT_WORKER_INTERVAL_MS = 500;
+const DEFAULT_WORKER_RESTART_MS = 2 * 1000;
+const DEFAULT_WORKER_INTERVAL_MS = 1;
 
 export async function spawnWalletWorker(
   actionQueue: Queue<ActionWithCont<any, any>>,

--- a/relayer/middleware/wallet/walletToolBox.ts
+++ b/relayer/middleware/wallet/walletToolBox.ts
@@ -19,7 +19,13 @@ export function createWalletToolbox(
   }
   switch (chainId) {
     case wh.CHAIN_ID_SOLANA:
-      return createSolanaWalletToolBox(providers, bs58.decode(privateKey));
+      let secretKey;
+      try {
+        secretKey = bs58.decode(privateKey);
+      } catch (e) {
+        secretKey = new Uint8Array(JSON.parse(privateKey));
+      }
+      return createSolanaWalletToolBox(providers, secretKey);
   }
 }
 

--- a/relayer/middleware/wallet/walletToolBox.ts
+++ b/relayer/middleware/wallet/walletToolBox.ts
@@ -1,4 +1,5 @@
 import * as wh from "@certusone/wormhole-sdk";
+import * as bs58 from "bs58";
 import { ethers } from "ethers";
 import * as solana from "@solana/web3.js";
 import { Providers } from "../providers.middleware";
@@ -18,10 +19,7 @@ export function createWalletToolbox(
   }
   switch (chainId) {
     case wh.CHAIN_ID_SOLANA:
-      return createSolanaWalletToolBox(
-        providers,
-        new Uint8Array(JSON.parse(privateKey))
-      );
+      return createSolanaWalletToolBox(providers, bs58.decode(privateKey));
   }
 }
 


### PR DESCRIPTION
* Adds monitoring to wallet middleware. It also prints out the public addresses for each wallet to the logs.
* It fixes an error when no redis config is passed in.
* Adds a `ctx.locals` property that you can use to store arbitrary data in your context to pass through function invokations akin to what koa has (`ctx.locals` or `ctx.state`).
* Metrics middleware accepts a prometheus registry.
* Last seen sequence is set when a workflow starts processing and not when it finishes.
* Adds new rpc information on providers middleware.
* Decorates `sourceTx` with `0x` if it's an EVM VAA so that `ethers` doesn't fail when you pass in the `txHash`.
* Lowers wallet inner queue polling delay to better compete against a simpler relayer in delivery teams (Drew's relayer beat ours consistently when racing for a VAA until this change).